### PR TITLE
Infurider YF-90EPD + macOS Moneterey compatability

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,18 +2,15 @@
 
 Get BLE Multimeter data to PC. With approx 2 samples per second (in DC Volt mode).
 
-Works for
+Works with FS9721-LP3 based Bluetooth Multimeters, including:
 
 * AOPUTTRIVER AP-90EPD
-
-Should also work for, maybe with different "CHARACTERISTIC_UUID"
+* Infurider YF-90EPD
 * HoldPeak HP-90EPD
-
-Multimeters via BLE (Bluetooth Low Energy) connection *without* prior pairing of the devices.
 
 <img src='img/multimeter.jpg' width="300px">
 
-Tested with Windows 10, Linux using Python 3.8 64-bit.
+Tested with Windows 10, macOS monterey, and Linux using Python 3.8 64-bit.
 
 ## Credits
 

--- a/bleak_scan.py
+++ b/bleak_scan.py
@@ -1,13 +1,18 @@
 import asyncio
 from bleak import discover
 import time
+from sys import platform
 
 # Your meter's MAC will probably start with A5:B3:C2...
 # and have the name "BDM"
 # A5:B3:C2:22:14:D2: BDM
 
 async def run():
-    devices = await discover()
+    kwargs = {} if platform != "darwin" else {
+        "service_uuids": ["0000ffb0-0000-1000-8000-00805f9b34fb"]
+    }
+
+    devices = await discover(**kwargs)
     for d in devices:
         print(d)
 


### PR DESCRIPTION
I stumbled across your repository and was curious, so I bought a similar looking BLE-enabled DMM and was able to confirm that this works on other models that use the same [FS9721-LP3 chip](https://cxem.net/ckfinder/userfiles/726ed1beaa237e1aab6b6e90e480e1b7/files/FS9721LP3.pdf)!

Just a little PR to:

1. Amend `bleak` calls to enable support on macOS Monterey (which has a frustrating amount of quirks to its Bluetooth stack 😞 ).
2. Update the README with confirmation that this works on similar multimeters (there are quite a few on Amazon with the same `**-90EPD` pattern to their model numbers).